### PR TITLE
docs: update example `actions/checkout` usage to v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ jobs:
   stainless:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: stainless-api/upload-openapi-spec-action@main
         with:
           stainless_api_key: ${{ secrets.STAINLESS_API_KEY }}
@@ -70,7 +70,7 @@ jobs:
   stainless:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: stainless-api/upload-openapi-spec-action@main
         with:
           stainless_api_key: ${{ secrets.STAINLESS_API_KEY }}
@@ -113,7 +113,7 @@ jobs:
   stainless:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Push spec and config to Stainless and outputs documented spec
         uses: stainless-api/upload-openapi-spec-action@main
         with:


### PR DESCRIPTION
The bump to v4 is largely a noop but the internals are now using node20.